### PR TITLE
Correccion de indices de tarjetas

### DIFF
--- a/resources/views/que_hacemos.blade.php
+++ b/resources/views/que_hacemos.blade.php
@@ -251,17 +251,20 @@
 
                         <div style="display: none">{{$flag = false}}</div>
                         @if($talleres != null)
-                            @for($i = 0;$i <= count($talleres)/3; $i++ )
+                            @for($i = 0; $i < count($talleres)/3; $i++)
                                 @if($flag == false)
                                     <div class="carousel-item active">
-                                        <div class="row">
+                                        <div class="row justify-content-center">
                                             @for($j = 0; $j < 3; $j++)
+                                                @if($i*3 + $j >= count($talleres))
+                                                    @break
+                                                @endif
                                                 <div class="col-md-4 mb-3">
                                                     <div class="card">
                                                         <img class="img-fluid" src="{{asset($talleres[$i + $j]->image)}}" onerror="this.onerror=null;this.src='{{asset('images/image-not-found.png')}}';">
                                                         <div class="card-body justify-content-center">
-                                                            <h4 class="card-title text-center">{{strtoupper($talleres[$i + $j]->name) }}</h4>
-                                                            <p class="card-text text-center">{{$talleres[$i + $j]->description}} </p>
+                                                            <h4 class="card-title text-center">{{strtoupper($talleres[$i*3 + $j]->name) }}</h4>
+                                                            <p class="card-text text-center">{{$talleres[$i*3 + $j]->description}} </p>
                                                         </div>
                                                     </div>
                                                 </div>
@@ -271,14 +274,17 @@
                                     <div style="display: none">{{$flag = true}}</div>
                                 @else
                                     <div class="carousel-item">
-                                        <div class="row">
+                                        <div class="row justify-content-center">
                                             @for($j = 0; $j < 3; $j++)
+                                                @if($i*3 + $j >= count($talleres))
+                                                    @break
+                                                @endif
                                                 <div class="col-md-4 mb-3">
                                                     <div class="card">
                                                         <img class="img-fluid" src="{{asset($talleres[$i + $j]->image)}}" onerror="this.onerror=null;this.src='{{asset('images/image-not-found.png')}}';">
                                                         <div class="card-body justify-content-center">
-                                                            <h4 class="card-title text-center">{{strtoupper($talleres[$i + $j]->name)}}</h4>
-                                                            <p class="card-text text-center">{{$talleres[$i + $j]->description}} </p>
+                                                            <h4 class="card-title text-center">{{strtoupper($talleres[$i*3 + $j]->name)}}</h4>
+                                                            <p class="card-text text-center">{{$talleres[$i*3 + $j]->description}} </p>
                                                         </div>
                                                     </div>
                                                 </div>


### PR DESCRIPTION
Se corrigio un error con los indices de los ciclos que desplegan las tarjetas estaba causando que se mostraran talleres repetidos y que no se mostraran todos.